### PR TITLE
feat(ci): Add build image job for PR checks 

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -71,3 +71,14 @@ jobs:
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: results.sarif
+
+  build-nimbus-image:
+    name: Build Nimbus Operator image
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v3
+
+      - name: Build image
+        run: make docker-build

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ docker-buildx: ## Build and push docker image for the manager for cross-platform
 	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
 	- $(CONTAINER_TOOL) buildx create --name project-v3-builder
 	$(CONTAINER_TOOL) buildx use project-v3-builder
-	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --build-arg VERSION=${TAG} --tag ${IMG}:${TAG} -f Dockerfile.cross .
+	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --build-arg VERSION=${TAG} --tag ${IMG}:${TAG} -f Dockerfile.cross . || { $(CONTAINER_TOOL) buildx rm project-v3-builder; rm Dockerfile.cross; exit 1; }
 	- $(CONTAINER_TOOL) buildx rm project-v3-builder
 	rm Dockerfile.cross
 


### PR DESCRIPTION
## Description
Fix the `docker-buildx` target to fail with an error if the build fails. Additionally, add a new job to the PR checks that builds the operator's docker image to ensure it can be built successfully before merging the PR.

<!--
Thank you for your pull request (PR)!
Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

Fixes # (issue)

**Does this PR introduce a breaking change?**
No

## Checklist

- [x] PR title follows the `<type>: <description>` convention
- [x] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
- [ ] I have updated the [documentation](../docs) accordingly
- [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional information for reviewer

#### Mention if this PR is part of any design or a continuation of previous PRs
First merge this [PR](https://github.com/5GSEC/nimbus/pull/19) because it has a [commit](https://github.com/5GSEC/nimbus/pull/19/commits/5413554733ebcbb9e535b9e90700998cc58b247a) to fix the Dockerfile

<!--
The PR title must follow `<type>: <description>` convention:

where: <br/>

- `type` is to define what type of PR is this, most common types are as follows:
    - `fix`   - for bug fixes or improvements.
    - `feat`  - for new features which adds functionality.
    - `chore` - for changes that do not relate to a fix or feature and don't modify src or test files.
    - `docs`  - for changes related to documentation.
    - `test`  - for changes related to tests.

- `description` is a single line brief description of the changes made in the pull request.
-->

<!--
Open your PR in Draft mode and verify all the applicable Checklist items before marking your issue as ready
-->
