### PR TITLE
fix(nimbus-netpol): Fix docker-buildx target to point correct context

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -83,7 +83,7 @@ jobs:
   build-adapters-image:
     strategy:
       matrix:
-        adapters: [ "nimbus-kubearmor", "nimbus-netpol" ]
+        adapters: [ "nimbus-kubearmor", "nimbus-netpol", "nimbus-kyverno" ]
     name: Build ${{ matrix.adapters }} adapter's image
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/pkg/adapter/nimbus-kyverno/Dockerfile
+++ b/pkg/adapter/nimbus-kyverno/Dockerfile
@@ -10,7 +10,6 @@ WORKDIR /nimbus
 
 # relative deps requried by the adapter
 ADD api/ api/
-ADD internal/ internal/
 ADD pkg/ pkg/
 ADD go.mod go.mod
 ADD go.sum go.sum

--- a/pkg/adapter/nimbus-kyverno/Makefile
+++ b/pkg/adapter/nimbus-kyverno/Makefile
@@ -31,6 +31,6 @@ docker-buildx:
 	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
 	- $(CONTAINER_TOOL) buildx create --name project-v3-builder
 	$(CONTAINER_TOOL) buildx use project-v3-builder
-	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --build-arg VERSION=${TAG} --tag ${IMG}:${TAG} -f Dockerfile.cross . || { $(CONTAINER_TOOL) buildx rm project-v3-builder; rm Dockerfile.cross; exit 1; }
+	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --build-arg VERSION=${TAG} --tag ${IMG}:${TAG} -f Dockerfile.cross ../../../ || { $(CONTAINER_TOOL) buildx rm project-v3-builder; rm Dockerfile.cross; exit 1; }
 	- $(CONTAINER_TOOL) buildx rm project-v3-builder
 	rm Dockerfile.cross

--- a/pkg/adapter/nimbus-netpol/Dockerfile
+++ b/pkg/adapter/nimbus-netpol/Dockerfile
@@ -8,9 +8,7 @@ ARG TARGETARCH
 
 WORKDIR /nimbus
 
-
 # relative deps requried by the adapter
-
 ADD api/ api/
 ADD pkg/ pkg/
 ADD go.mod go.mod
@@ -32,7 +30,6 @@ COPY $ADAPTER_DIR/manager manager
 COPY $ADAPTER_DIR/processor processor
 COPY $ADAPTER_DIR/watcher watcher
 COPY $ADAPTER_DIR/main.go main.go
-
 
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command

--- a/pkg/adapter/nimbus-netpol/Makefile
+++ b/pkg/adapter/nimbus-netpol/Makefile
@@ -31,6 +31,6 @@ docker-buildx:
 	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
 	- $(CONTAINER_TOOL) buildx create --name project-v3-builder
 	$(CONTAINER_TOOL) buildx use project-v3-builder
-	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --build-arg VERSION=${TAG} --tag ${IMG}:${TAG} -f Dockerfile.cross . || { $(CONTAINER_TOOL) buildx rm project-v3-builder; rm Dockerfile.cross; exit 1; }
+	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --build-arg VERSION=${TAG} --tag ${IMG}:${TAG} -f Dockerfile.cross ../../../ || { $(CONTAINER_TOOL) buildx rm project-v3-builder; rm Dockerfile.cross; exit 1; }
 	- $(CONTAINER_TOOL) buildx rm project-v3-builder
 	rm Dockerfile.cross


### PR DESCRIPTION
## Description

<!--
Thank you for your pull request (PR)!
Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

This PR fixes the `nimbus-netpol` adapter cross-image build which was failing due to the wrong context.
Related to #87 
GHA: https://github.com/5GSEC/nimbus/actions/runs/8393563828/job/22988790875

**Does this PR introduce a breaking change?**
No

## Checklist

- [x] PR title follows the `<type>: <description>` convention
- [x] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
- [ ] I have updated the [documentation](../docs) accordingly
- [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional information for reviewer

#### Mention if this PR is part of any design or a continuation of previous PRs

<!--
The PR title must follow `<type>: <description>` convention:

where: <br/>

- `type` is to define what type of PR is this, most common types are as follows:
    - `fix`   - for bug fixes or improvements.
    - `feat`  - for new features which adds functionality.
    - `chore` - for changes that do not relate to a fix or feature and don't modify src or test files.
    - `docs`  - for changes related to documentation.
    - `test`  - for changes related to tests.

- `description` is a single line brief description of the changes made in the pull request.
-->

<!--
Open your PR in Draft mode and verify all the applicable Checklist items before marking your issue as ready
-->
