### PR TITLE
fix: Modifying the trigger for the mutateexisting policy to the Nimbus policy

### DIFF
--- a/pkg/adapter/nimbus-kyverno/processor/kpbuilder.go
+++ b/pkg/adapter/nimbus-kyverno/processor/kpbuilder.go
@@ -185,9 +185,9 @@ func cocoRuntimeAddition(np *v1alpha1.NimbusPolicy) ([]kyvernov1.Policy, error) 
 							kyvernov1.ResourceFilter{
 								ResourceDescription: kyvernov1.ResourceDescription{
 									Kinds: []string{
-										"v1/ConfigMap",
+										"intent.security.nimbus.com/v1alpha1/NimbusPolicy",
 									},
-									Name: np.Name + "-mutateexisting-trigger-configmap",
+									Name: np.Name,
 								},
 							},
 						},


### PR DESCRIPTION
   Modifying the trigger for the mutateexisting policy to a Nimbus policy. Since it is guaranteed 
   that a nimbus policy will be created before a mutateexisting policy, we can ensure that the mutateexisting
   policy will always be triggered. 

## Description

<!--
Thank you for your pull request (PR)!
Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

Fixes #215

**Does this PR introduce a breaking change?**
No

## Checklist

- [*] PR title follows the `<type>: <description>` convention
- [*] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
- [ ] I have updated the [documentation](../docs) accordingly
- [*] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [*] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional information for reviewer
I have tested in my local setup (make run of the nimbus-kyverno adapter), and it works.

#### Mention if this PR is part of any design or a continuation of previous PRs

<!--
The PR title must follow `<type>: <description>` convention:

where: <br/>

- `type` is to define what type of PR is this, most common types are as follows:
    - `fix`   - for bug fixes or improvements.
    - `feat`  - for new features which adds functionality.
    - `chore` - for changes that do not relate to a fix or feature and don't modify src or test files.
    - `docs`  - for changes related to documentation.
    - `test`  - for changes related to tests.

- `description` is a single line brief description of the changes made in the pull request.
-->

<!--
Open your PR in Draft mode and verify all the applicable Checklist items before marking your issue as ready
-->
